### PR TITLE
Fix sign-in link on create-account page

### DIFF
--- a/www/source/tutorials/download/create-account.html.slim
+++ b/www/source/tutorials/download/create-account.html.slim
@@ -11,7 +11,7 @@ section.download
 
   p As part of the sign-in process, the Habitat Builder requires GitHub authorization. Only your email address associated with your GitHub account is shared as part of the authorization request.
 
-  = link_to 'Sign Into Builder', '#{builder_web_url}/#/sign-in', class: 'button cta', target: '_blank'
+  = link_to 'Sign Into Builder', "#{builder_web_url}/#/sign-in", class: 'button cta', target: '_blank'
 
   .screenshot
     img src="/images/screenshots/authorize.png"


### PR DESCRIPTION
The sign-in link on the create-account page uses the wrong quotes, so the interpolation isn't working.